### PR TITLE
No need for setting the constructor parameter to the member variable

### DIFF
--- a/ionicslidebox2/src/providers/image-search.ts
+++ b/ionicslidebox2/src/providers/image-search.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Http, Headers} from '@angular/http';
 import 'rxjs/add/operator/map';
-import { Observable } from 'rxjs/Observable';
 
 /*
   Generated class for the ImageSearch provider.
@@ -16,7 +15,6 @@ export class ImageSearch {
   rooturl = "https://api.datamarket.azure.com/Bing/Search/v1/Image?$format=json&Query='";
 
   constructor(public http: Http) {
-    this.http = http;
   }
 
   search(term:string) {


### PR DESCRIPTION
Typescript does this automatically when the constructor parameter is prefixed 
with private, public, protected  and/or readonly